### PR TITLE
refractor: uses macros with Rust 2018 pattern

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate juniper;
-
 use actix::prelude::*;
 use actix_web::{
     server, App, AsyncResponder, 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,6 @@
-use juniper::{FieldResult, RootNode};
+use juniper::{FieldResult, RootNode, graphql_object};
+use juniper::{GraphQLObject, GraphQLInputObject};
+
 use uuid::Uuid;
 use chrono::prelude::*;
 


### PR DESCRIPTION
- import graphql_object! macros using Rust 2018 approach
- import GraphQLObject and GraphQLInput object with same approach